### PR TITLE
fix link to github repo in layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -109,7 +109,7 @@ export default function RootLayout({
               </a>
               <a
                 className="flex gap-2 px-3 py-2 text-sm font-semibold text-gray-600 transition duration-100 rounded-md hover:text-gray-800"
-                href="https://github.com/devagrawal09/clerk-nextjs-template"
+                href="https://github.com/clerkinc/clerk-next-app"
               >
                 <div className="m-auto">
                   <Github />


### PR DESCRIPTION
the previous link was for an old github url. this one uses its new official resting place
